### PR TITLE
Initial cut at Docker container approach to data processing

### DIFF
--- a/containers/gather_docs/Dockerfile
+++ b/containers/gather_docs/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+COPY . .
+
+CMD [ "python3", "app.py"]

--- a/containers/gather_docs/README.md
+++ b/containers/gather_docs/README.md
@@ -1,0 +1,3 @@
+# Documentation Builder
+
+This container implements a process for gathering and packaging data documentation for the EPA ECHO data we are bringing into the EEW cache. We attempt to pull in formal, structured metadata for source data wherever possible, and resort to web scraping or other parsing methods when necessary. The end target is a suite of [JSON Schema](https://json-schema.org) documents that can be used to share descriptive information for human consumption or applied with tools to run data validation tests.

--- a/containers/gather_docs/app.py
+++ b/containers/gather_docs/app.py
@@ -1,0 +1,85 @@
+import requests
+from bs4 import BeautifulSoup
+import pandas as pd
+from pprint import pprint
+
+rcra_entity_map = {
+    "RCRA_FACILITIES.csv": {
+        "table_index": 1
+    },
+    "RCRA_ENFORCEMENTS.csv": {
+        "table_index": 2
+    },
+    "RCRA_EVALUATIONS.csv": {
+        "table_index": 3
+    },
+    "RCRA_VIOLATIONS.csv": {
+        "table_index": 4
+    },
+    "RCRA_NAICS.csv": {
+        "table_index": 5
+    },
+    "RCRA_VIOSNC_HISTORY.csv": {
+        "table_index": 6
+    },
+}
+
+def parse_doc_content():
+    url = "https://echo.epa.gov/tools/data-downloads/rcrainfo-download-summary"
+    r = requests.get(url)
+    if r.status_code != 200:
+        raise(ValueError(f"Web site could not be retrieved. Status Code: {r.status_code}"))
+
+    # Get the tables into a list of dataframes
+    tables = pd.read_html(r.text)
+
+    # Work through each dataframe/table corresponding to a RCRA table and stub out a JSON Schema document
+    schemas = list()
+    for entity,config in rcra_entity_map.items():
+        schema = {
+            "$schema": "http://json-schema.org/draft-07/schema",
+            "$id": f"epa:{entity.split('.')[0].lower()}",
+            "type": "object",
+            "title": f"{entity} Schema",
+            "description": "",
+            "properties": dict()
+        }
+        property_table = tables[int(config["table_index"])].copy()
+        for col in [i for i in property_table.columns if i not in ["Element","Data Type"]]:
+            property_table = property_table.drop(col, 1)
+        property_table.columns = ["title","type"]
+        property_table["$id"] = property_table["title"].apply(lambda x: f"{schema['$id']}:{x.lower()}")
+        for index, row in property_table.iterrows():
+            schema["properties"][row["title"]] = {
+                "$id": row["$id"],
+                "type": row["type"],
+                "title": row["title"]
+            }
+        schemas.append(schema)
+
+    # Work through the descriptive content and inject property descriptions into the appropriate schema docs
+    doc_soup = BeautifulSoup(r.text, 'lxml')
+    for i in doc_soup.find_all('h3'):
+        table_name = i.text[i.text.find("(")+1:i.text.find(")")]
+        if table_name and ".csv" in table_name:
+            schema_id = ":".join(["epa",table_name.split(".")[0].lower()])
+            for sib in i.next_siblings:
+                if sib.name == 'p':
+                    p_parts = sib.text.split("-")
+                    if len(p_parts) > 1:
+                        property_name = p_parts[0].strip()
+                        schema = next((i for i in schemas if i["$id"] == schema_id), None)
+                        if schema is not None and property_name in schema["properties"]:
+                            schema["properties"][property_name]["description"] = "-".join(p_parts[1:])
+                elif sib.name == 'h3':
+                    break
+
+    return schemas
+
+if __name__ == '__main__':
+    rcra_schemas = parse_doc_content()
+    
+    # Just print out each schema to console for now
+    # Need to come up with a destination to write the schemas
+    for schema in rcra_schemas:
+        pprint(schema)

--- a/containers/gather_docs/requirements.txt
+++ b/containers/gather_docs/requirements.txt
@@ -1,0 +1,4 @@
+beautifulsoup4==4.10.0
+requests==2.26.0
+pandas==1.3.3
+lxml==4.6.3


### PR DESCRIPTION
Following some discussion in Slack about scraping documentation from EPA's web site for tables in the ECHO database cache we have for the EEW project, I laid out a potential approach. I also took the opportunity to show how we might break up other aspects of data/metadata gathering in a container approach. The containers folder that is part of this pull request could be a useful pattern where we have a whole set of logical "microservices" that execute the work needed to collect and process data and metadata for use.

The source code for an initial cut at pulling together RCRA data documentation is included in the pull. I went ahead and set up a DockerHub repo for this work and pushed that image [here](https://hub.docker.com/layers/167219225/skybristol/eew/epa-echo-doc-gather/images/sha256-38533ddb09476a1509cd6255300123e1a181207ff32fc203ef640bbfabc3bba1?context=repo) if anyone wants to test out the compiled container image. Right now, this just builds documentation in the JSON Schema specification for the individual RCRA CSVs and dumps it to standard out. I'd like to learn more about how and where the data are flowing and talk about the best place to store and serve schema documentation like this. The JSON Schema spec can be used in a variety of ways to not only share the human-readable descriptive stuff but also run data validation checks to ensure we are getting what we think we should be getting.